### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.dockerignore
+.env-example
+.gitignore
+Dockerfile
+LICENSE
+README.md F

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir /ehb
 RUN mkdir /ehb/media
 
 WORKDIR /ehb
+COPY . /ehb/
 
 RUN chown daemon /ehb
 RUN chmod 705 /ehb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:16-alpine
+
+RUN mkdir /ehb 
+RUN mkdir /ehb/media
+
+WORKDIR /ehb
+
+RUN chown daemon /ehb
+RUN chmod 705 /ehb
+RUN npm install
+
+USER daemon
+CMD ["pm2 start -f index.js --name ${ACCOUNT_NAME}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16-alpine
 
+ENV ISDOCKER=true
+
 RUN mkdir /ehb 
 RUN mkdir /ehb/media
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN chmod 705 /ehb
 RUN npm install
 
 USER daemon
-CMD ["pm2 start -f index.js --name ${ACCOUNT_NAME}"]
+CMD ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN mkdir /ehb/media
 WORKDIR /ehb
 COPY . /ehb/
 
-RUN chown daemon /ehb
-RUN chmod 705 /ehb
+RUN chown -R daemon /ehb
+RUN chmod -R 705 /ehb
 RUN npm install
 
 USER daemon

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ NodeJS 16
 Twitter Developer Account with evelated permissions and access to Twitter V1 API
 
 ## Quick Start using Docker
-1. [Install Docker](https://docs.docker.com/engine/install/) that includes V2 Compose. This should be standard for any release after April 2022.
+1. [Clone the repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) into a location you want it to run from.
+1. [Install Docker](https://docs.docker.com/engine/install/), ideally a version that includes V2 Compose. This should be standard for any release after April 2022.
 1. Edit the `docker-compose.yaml` file to adjust environment variable values.
 1. Create a `media` directory in the same path as `docker-compose.yaml` and `index.js`. 
 1. `docker compose up` 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Thanks to [IzzyMG](https://github.com/izzymg) for the help fixing up parts of th
 NodeJS 16
 Twitter Developer Account with evelated permissions and access to Twitter V1 API
 
+## Quick Start using Docker
+1. [Install Docker](https://docs.docker.com/engine/install/) that includes V2 Compose. This should be standard for any release after April 2022.
+1. Edit the `docker-compose.yaml` file to adjust environment variable values.
+1. Create a `media` directory in the same path as `docker-compose.yaml` and `index.js`. 
+1. `docker compose up` 
+1. You're done! No fiddling with RHEL, no worrying about your environment.
+
 ## How to use  
 These instructions are for running the bot on a Linux/Windows server system. Code not designed to run on serverless infrastructure like AWS Lambda, Azure Functions or running on Heroku.  
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,13 +3,13 @@ services:
   ehb:
     build: .
     environment:
-    - CONSUMER_KEY=""
-    - CONSUMER_SECRET=""
-    - ACCESS_TOKEN_KEY=""
-    - ACCESS_TOKEN_SECRET=""
-    - USE_TWITTER="true"
-    - USE_MASTODON="false"
-    - MASTODON_SERVER=""
-    - MASTODON_ACCESS_TOKEN=""
+      CONSUMER_KEY: ""
+      CONSUMER_SECRET: ""
+      ACCESS_TOKEN_KEY: ""
+      ACCESS_TOKEN_SECRET: ""
+      USE_TWITTER: true
+      USE_MASTODON: false
+      MASTODON_SERVER: ""
+      MASTODON_ACCESS_TOKEN: ""
     volumes:
     - ./media:/ehb/media 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,4 +12,4 @@ services:
     - MASTODON_SERVER=""
     - MASTODON_ACCESS_TOKEN=""
     volumes:
-    - ./media:./ehb/media 
+    - ./media:/ehb/media 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,8 @@
 version: "3.4"
 services:
   ehb:
-    image: repository/every-hour-bot
+    build: .
     environment:
-    - ACCOUNT_NAME=""
     - CONSUMER_KEY=""
     - CONSUMER_SECRET=""
     - ACCESS_TOKEN_KEY=""
@@ -13,4 +12,4 @@ services:
     - MASTODON_SERVER=""
     - MASTODON_ACCESS_TOKEN=""
     volumes:
-    - ./media:./media 
+    - ./media:./ehb/media 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.4"
+services:
+  ehb:
+    image: repository/every-hour-bot
+    environment:
+    - ACCOUNT_NAME=""
+    - CONSUMER_KEY=""
+    - CONSUMER_SECRET=""
+    - ACCESS_TOKEN_KEY=""
+    - ACCESS_TOKEN_SECRET=""
+    - USE_TWITTER="true"
+    - USE_MASTODON="false"
+    - MASTODON_SERVER=""
+    - MASTODON_ACCESS_TOKEN=""
+    volumes:
+    - ./media:./media 


### PR DESCRIPTION
This branch creates three new files all in relation to managing container images. 

The Dockerfile is very basic, it uses the alpine version of the Node v16 image so that we can keep the image small. This is a first attempt and I'm sure we can get this down even smaller, but currently we're sitting at at total size of 128.95MB.

The docker-compose.yaml file is there because all recent versions of docker come bundles with compose, so it's safe to assume the average user will have access to this without running additional installs. Compose allows us to simplify the setup process by using a single config. 

The .dockerignore works similarly to .gitignore except it's only for copying resources into the container. 

A given user would simply need to install docker, adjust the `docker-compose.yaml` to fit their config needs, populate a `./media` directory in the same `$PWD` as the `docker-compose.yaml` and then `docker compose up`. No more fussing with Node or RHEL8 or anything. 

One thing to note: the repository for this image would still need to be defined. I don't want to send this to mine and steal your thunder.